### PR TITLE
Add dask support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -112,7 +112,9 @@ python-versions = ">=3.8"
 click = ">=7.0"
 cloudpickle = ">=1.1.1"
 fsspec = ">=0.6.0"
+numpy = {version = ">=1.18", optional = true, markers = "extra == \"dataframe\""}
 packaging = ">=20.0"
+pandas = {version = ">=1.0", optional = true, markers = "extra == \"dataframe\""}
 partd = ">=0.3.10"
 pyyaml = ">=5.3.1"
 toolz = ">=0.8.2"
@@ -299,6 +301,22 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
+name = "pandas"
+version = "1.5.1"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+numpy = {version = ">=1.21.0", markers = "python_version >= \"3.10\""}
+python-dateutil = ">=2.8.1"
+pytz = ">=2020.1"
+
+[package.extras]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
+
+[[package]]
 name = "partd"
 version = "1.3.0"
 description = "Appendable key-value storage"
@@ -354,6 +372,17 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "pyarrow"
+version = "6.0.1"
+description = "Python library for Apache Arrow"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+numpy = ">=1.16.6"
+
+[[package]]
 name = "pycodestyle"
 version = "2.9.1"
 description = "Python style guide checker"
@@ -399,6 +428,25 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "pytz"
+version = "2022.6"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "pyyaml"
@@ -507,6 +555,23 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "tqdm"
+version = "4.64.1"
+description = "Fast, Extensible Progress Meter"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "urllib3"
 version = "1.26.12"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -539,7 +604,7 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "af27e3497ff992bb46c9449dd298b2f8ce39db4f0615d6fde1895676e3ac93a6"
+content-hash = "babfdd200349e3df42cb3e1baabf1f880c9e0f77534a349cf67cadcf6c008ac8"
 
 [metadata.files]
 aiosignal = []
@@ -567,15 +632,19 @@ locket = []
 msgpack = []
 numpy = []
 packaging = []
+pandas = []
 partd = []
 pbr = []
 platformdirs = []
 pluggy = []
 protobuf = []
+pyarrow = []
 pycodestyle = []
 pyparsing = []
 pyrsistent = []
 pytest = []
+python-dateutil = []
+pytz = []
 pyyaml = []
 ray = []
 requests = []
@@ -584,5 +653,6 @@ smmap = []
 stevedore = []
 tomli = []
 toolz = []
+tqdm = []
 urllib3 = []
 virtualenv = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,588 @@
+[[package]]
+name = "aiosignal"
+version = "1.3.1"
+description = "aiosignal: a list of registered asynchronous callbacks"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+frozenlist = ">=1.1.0"
+
+[[package]]
+name = "attrs"
+version = "22.1.0"
+description = "Classes Without Boilerplate"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
+name = "autopep8"
+version = "2.0.0"
+description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycodestyle = ">=2.9.1"
+tomli = "*"
+
+[[package]]
+name = "bandit"
+version = "1.7.4"
+description = "Security oriented static analyser for python code."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
+GitPython = ">=1.0.1"
+PyYAML = ">=5.3.1"
+stevedore = ">=1.20.0"
+
+[package.extras]
+test = ["coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)", "toml", "beautifulsoup4 (>=4.8.0)", "pylint (==1.9.4)"]
+toml = ["toml"]
+yaml = ["pyyaml"]
+
+[[package]]
+name = "certifi"
+version = "2022.9.24"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.1.1"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "click"
+version = "8.0.4"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "cloudpickle"
+version = "2.2.0"
+description = "Extended pickling support for Python objects"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+
+[[package]]
+name = "dask"
+version = "2022.10.2"
+description = "Parallel PyData with Task Scheduling"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+click = ">=7.0"
+cloudpickle = ">=1.1.1"
+fsspec = ">=0.6.0"
+packaging = ">=20.0"
+partd = ">=0.3.10"
+pyyaml = ">=5.3.1"
+toolz = ">=0.8.2"
+
+[package.extras]
+array = ["numpy (>=1.18)"]
+complete = ["bokeh (>=2.4.2,<3)", "distributed (==2022.10.2)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
+dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
+diagnostics = ["bokeh (>=2.4.2,<3)", "jinja2"]
+distributed = ["distributed (==2022.10.2)"]
+test = ["pandas", "pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
+
+[[package]]
+name = "distlib"
+version = "0.3.6"
+description = "Distribution utilities"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.0.1"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
+name = "filelock"
+version = "3.8.0"
+description = "A platform independent file lock."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
+testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
+
+[[package]]
+name = "frozenlist"
+version = "1.3.3"
+description = "A list-like structure which implements collections.abc.MutableSequence"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "fsspec"
+version = "2022.11.0"
+description = "File-system specification"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+abfs = ["adlfs"]
+adl = ["adlfs"]
+arrow = ["pyarrow (>=1)"]
+dask = ["dask", "distributed"]
+dropbox = ["dropboxdrivefs", "requests", "dropbox"]
+entrypoints = ["importlib-metadata"]
+fuse = ["fusepy"]
+gcs = ["gcsfs"]
+git = ["pygit2"]
+github = ["requests"]
+gs = ["gcsfs"]
+gui = ["panel"]
+hdfs = ["pyarrow (>=1)"]
+http = ["requests", "aiohttp (!=4.0.0a0,!=4.0.0a1)"]
+libarchive = ["libarchive-c"]
+oci = ["ocifs"]
+s3 = ["s3fs"]
+sftp = ["paramiko"]
+smb = ["smbprotocol"]
+ssh = ["paramiko"]
+tqdm = ["tqdm"]
+
+[[package]]
+name = "gitdb"
+version = "4.0.9"
+description = "Git Object Database"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.29"
+description = "GitPython is a python library used to interact with Git repositories"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[[package]]
+name = "grpcio"
+version = "1.50.0"
+description = "HTTP/2-based RPC framework"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+six = ">=1.5.2"
+
+[package.extras]
+protobuf = ["grpcio-tools (>=1.50.0)"]
+
+[[package]]
+name = "idna"
+version = "3.4"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "jsonschema"
+version = "4.17.0"
+description = "An implementation of JSON Schema validation for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=17.4.0"
+pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
+
+[[package]]
+name = "locket"
+version = "1.0.0"
+description = "File-based locks for Python on Linux and Windows"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "msgpack"
+version = "1.0.4"
+description = "MessagePack serializer"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "numpy"
+version = "1.23.4"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "partd"
+version = "1.3.0"
+description = "Appendable key-value storage"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+locket = "*"
+toolz = "*"
+
+[package.extras]
+complete = ["numpy (>=1.9.0)", "pandas (>=0.19.0)", "pyzmq", "blosc"]
+
+[[package]]
+name = "pbr"
+version = "5.11.0"
+description = "Python Build Reasonableness"
+category = "dev"
+optional = false
+python-versions = ">=2.6"
+
+[[package]]
+name = "platformdirs"
+version = "2.5.3"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.19.4)", "sphinx (>=5.3)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest (>=7.2)"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "protobuf"
+version = "4.21.9"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "pycodestyle"
+version = "2.9.1"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "main"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["railroad-diagrams", "jinja2"]
+
+[[package]]
+name = "pyrsistent"
+version = "0.19.2"
+description = "Persistent/Functional/Immutable data structures"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "pytest"
+version = "7.2.0"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "ray"
+version = "2.1.0"
+description = "Ray provides a simple, universal API for building distributed applications."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+aiosignal = "*"
+attrs = "*"
+click = ">=7.0,<=8.0.4"
+filelock = "*"
+frozenlist = "*"
+grpcio = {version = ">=1.42.0", markers = "python_version >= \"3.10\""}
+jsonschema = "*"
+msgpack = ">=1.0.0,<2.0.0"
+numpy = {version = ">=1.19.3", markers = "python_version >= \"3.9\""}
+packaging = {version = "*", markers = "python_version >= \"3.10\""}
+protobuf = ">=3.15.3,<3.19.5 || >3.19.5"
+pyyaml = "*"
+requests = "*"
+virtualenv = ">=20.0.24"
+
+[package.extras]
+air = ["colorful", "opencensus", "prometheus-client (>=0.7.1,<0.14.0)", "fastapi", "pandas (>=1.3)", "gpustat (>=1.0.0)", "pydantic", "py-spy (>=0.2.0)", "tensorboardX (>=1.9)", "starlette", "fsspec", "pyarrow (>=6.0.1,<7.0.0)", "tabulate", "requests", "smart-open", "numpy (>=1.20)", "pandas", "aiorwlock", "uvicorn", "aiohttp (>=3.7)", "aiohttp-cors"]
+all = ["colorful", "opencensus", "prometheus-client (>=0.7.1,<0.14.0)", "fastapi", "ray-cpp (==2.1.0)", "pandas (>=1.3)", "opentelemetry-api (==1.1.0)", "gpustat (>=1.0.0)", "pydantic", "py-spy (>=0.2.0)", "tensorboardX (>=1.9)", "kubernetes", "starlette", "dm-tree", "gym (>=0.21.0,<0.24.0)", "urllib3", "fsspec", "pyarrow (>=6.0.1,<7.0.0)", "tabulate", "requests", "lz4", "pyyaml", "kopf", "scipy", "smart-open", "numpy (>=1.20)", "pandas", "matplotlib (!=3.4.3)", "aiorwlock", "uvicorn", "opentelemetry-exporter-otlp (==1.1.0)", "aiohttp (>=3.7)", "scikit-image", "opentelemetry-sdk (==1.1.0)", "aiohttp-cors"]
+cpp = ["ray-cpp (==2.1.0)"]
+data = ["numpy (>=1.20)", "pandas (>=1.3)", "pyarrow (>=6.0.1,<7.0.0)", "fsspec"]
+default = ["aiohttp (>=3.7)", "aiohttp-cors", "colorful", "py-spy (>=0.2.0)", "requests", "gpustat (>=1.0.0)", "opencensus", "pydantic", "prometheus-client (>=0.7.1,<0.14.0)", "smart-open"]
+k8s = ["kubernetes", "urllib3", "kopf"]
+observability = ["opentelemetry-api (==1.1.0)", "opentelemetry-sdk (==1.1.0)", "opentelemetry-exporter-otlp (==1.1.0)"]
+rllib = ["pandas", "tabulate", "tensorboardX (>=1.9)", "requests", "dm-tree", "gym (>=0.21.0,<0.24.0)", "lz4", "matplotlib (!=3.4.3)", "scikit-image", "pyyaml", "scipy"]
+serve = ["smart-open", "colorful", "opencensus", "requests", "fastapi", "prometheus-client (>=0.7.1,<0.14.0)", "gpustat (>=1.0.0)", "aiohttp (>=3.7)", "pydantic", "aiorwlock", "py-spy (>=0.2.0)", "aiohttp-cors", "uvicorn", "starlette"]
+train = ["pandas", "tabulate", "tensorboardX (>=1.9)", "requests"]
+tune = ["pandas", "tabulate", "tensorboardX (>=1.9)", "requests"]
+
+[[package]]
+name = "requests"
+version = "2.28.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "smmap"
+version = "5.0.0"
+description = "A pure Python implementation of a sliding window memory map manager"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "stevedore"
+version = "4.1.1"
+description = "Manage dynamic plugins for Python applications"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+pbr = ">=2.0.0,<2.1.0 || >2.1.0"
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "toolz"
+version = "0.12.0"
+description = "List processing tools and functional utilities"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "urllib3"
+version = "1.26.12"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+
+[package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "virtualenv"
+version = "20.16.6"
+description = "Virtual Python Environment builder"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+distlib = ">=0.3.6,<1"
+filelock = ">=3.4.1,<4"
+platformdirs = ">=2.4,<3"
+
+[package.extras]
+docs = ["proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-argparse (>=0.3.2)", "sphinx-rtd-theme (>=1)", "towncrier (>=22.8)"]
+testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.10"
+content-hash = "af27e3497ff992bb46c9449dd298b2f8ce39db4f0615d6fde1895676e3ac93a6"
+
+[metadata.files]
+aiosignal = []
+attrs = []
+autopep8 = []
+bandit = []
+certifi = []
+charset-normalizer = []
+click = []
+cloudpickle = []
+colorama = []
+dask = []
+distlib = []
+exceptiongroup = []
+filelock = []
+frozenlist = []
+fsspec = []
+gitdb = []
+gitpython = []
+grpcio = []
+idna = []
+iniconfig = []
+jsonschema = []
+locket = []
+msgpack = []
+numpy = []
+packaging = []
+partd = []
+pbr = []
+platformdirs = []
+pluggy = []
+protobuf = []
+pycodestyle = []
+pyparsing = []
+pyrsistent = []
+pytest = []
+pyyaml = []
+ray = []
+requests = []
+six = []
+smmap = []
+stevedore = []
+tomli = []
+toolz = []
+urllib3 = []
+virtualenv = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -250,6 +250,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "joblib"
+version = "1.2.0"
+description = "Lightweight pipelining with Python functions"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "jsonschema"
 version = "4.17.0"
 description = "An implementation of JSON Schema validation for Python"
@@ -365,11 +373,11 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "protobuf"
-version = "4.21.9"
-description = ""
+version = "3.19.6"
+description = "Protocol Buffers"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.5"
 
 [[package]]
 name = "pyarrow"
@@ -475,9 +483,12 @@ jsonschema = "*"
 msgpack = ">=1.0.0,<2.0.0"
 numpy = {version = ">=1.19.3", markers = "python_version >= \"3.9\""}
 packaging = {version = "*", markers = "python_version >= \"3.10\""}
+pandas = {version = "*", optional = true, markers = "extra == \"tune\""}
 protobuf = ">=3.15.3,<3.19.5 || >3.19.5"
 pyyaml = "*"
 requests = "*"
+tabulate = {version = "*", optional = true, markers = "extra == \"tune\""}
+tensorboardX = {version = ">=1.9", optional = true, markers = "extra == \"tune\""}
 virtualenv = ">=20.0.24"
 
 [package.extras]
@@ -512,6 +523,42 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "scikit-learn"
+version = "1.1.3"
+description = "A set of python modules for machine learning and data mining"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+joblib = ">=1.0.0"
+numpy = ">=1.17.3"
+scipy = ">=1.3.2"
+threadpoolctl = ">=2.0.0"
+
+[package.extras]
+benchmark = ["matplotlib (>=3.1.2)", "pandas (>=1.0.5)", "memory-profiler (>=0.57.0)"]
+docs = ["matplotlib (>=3.1.2)", "scikit-image (>=0.16.2)", "pandas (>=1.0.5)", "seaborn (>=0.9.0)", "memory-profiler (>=0.57.0)", "sphinx (>=4.0.1)", "sphinx-gallery (>=0.7.0)", "numpydoc (>=1.2.0)", "Pillow (>=7.1.2)", "sphinx-prompt (>=1.3.0)", "sphinxext-opengraph (>=0.4.2)"]
+examples = ["matplotlib (>=3.1.2)", "scikit-image (>=0.16.2)", "pandas (>=1.0.5)", "seaborn (>=0.9.0)"]
+tests = ["matplotlib (>=3.1.2)", "scikit-image (>=0.16.2)", "pandas (>=1.0.5)", "pytest (>=5.0.1)", "pytest-cov (>=2.9.0)", "flake8 (>=3.8.2)", "black (>=22.3.0)", "mypy (>=0.961)", "pyamg (>=4.0.0)", "numpydoc (>=1.2.0)"]
+
+[[package]]
+name = "scipy"
+version = "1.9.3"
+description = "Fundamental algorithms for scientific computing in Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+numpy = ">=1.18.5,<1.26.0"
+
+[package.extras]
+test = ["pytest", "pytest-cov", "pytest-xdist", "asv", "mpmath", "gmpy2", "threadpoolctl", "scikit-umfpack"]
+doc = ["sphinx (!=4.1.0)", "pydata-sphinx-theme (==0.9.0)", "sphinx-panels (>=0.5.2)", "matplotlib (>2)", "numpydoc", "sphinx-tabs"]
+dev = ["mypy", "typing-extensions", "pycodestyle", "flake8"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -537,6 +584,38 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
+
+[[package]]
+name = "tabulate"
+version = "0.9.0"
+description = "Pretty-print tabular data"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
+name = "tensorboardx"
+version = "2.5"
+description = "TensorBoardX lets you watch Tensors Flow without Tensorflow"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+numpy = "*"
+protobuf = ">=3.8.0"
+six = "*"
+
+[[package]]
+name = "threadpoolctl"
+version = "3.1.0"
+description = "threadpoolctl"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "tomli"
@@ -604,7 +683,7 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "babfdd200349e3df42cb3e1baabf1f880c9e0f77534a349cf67cadcf6c008ac8"
+content-hash = "357bf326b148dfc38393f5a89727085a01034417a12199c3ae7ba7d124a1b72a"
 
 [metadata.files]
 aiosignal = []
@@ -627,6 +706,7 @@ gitpython = []
 grpcio = []
 idna = []
 iniconfig = []
+joblib = []
 jsonschema = []
 locket = []
 msgpack = []
@@ -648,9 +728,14 @@ pytz = []
 pyyaml = []
 ray = []
 requests = []
+scikit-learn = []
+scipy = []
 six = []
 smmap = []
 stevedore = []
+tabulate = []
+tensorboardx = []
+threadpoolctl = []
 tomli = []
 toolz = []
 tqdm = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,10 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-dask = "^2022.10.2"
+dask = {extras = ["dataframe"], version = "^2022.10.2"}
 ray = "^2.1.0"
+pyarrow = "^6.0.1"
+tqdm = "^4.64.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "mlray"
+version = "0.1.0"
+description = "Sample project demonstrating how to use Ray to build ML projects"
+authors = ["Willem Meints <1550763+wmeints@users.noreply.github.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+dask = "^2022.10.2"
+ray = "^2.1.0"
+
+[tool.poetry.dev-dependencies]
+pytest = "^7.2.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,11 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.10"
 dask = {extras = ["dataframe"], version = "^2022.10.2"}
-ray = "^2.1.0"
+ray = {extras = ["tune"], version = "^2.1.0"}
 pyarrow = "^6.0.1"
 tqdm = "^4.64.1"
+scikit-learn = "^1.1.3"
+protobuf = "<3.20"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ ray = "^2.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"
+bandit = "^1.7.4"
+autopep8 = "^2.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ray[air]==2.1.0
 ray[tune]==2.1.0
 scikit-learn==1.0.2
 tqdm==4.64.1
+dask==2022.2.0

--- a/src/prepare_data.py
+++ b/src/prepare_data.py
@@ -1,7 +1,6 @@
 import ray
 import dask.dataframe as dd
 from ray.util.dask import enable_dask_on_ray
-from ray.data.preprocessors import OneHotEncoder
 
 
 def load_data(filename):
@@ -36,7 +35,7 @@ def main():
 
     enable_dask_on_ray()
 
-    dataset_preprocessed = load_data('data/wachttijden.csv')
+    dataset_preprocessed = load_data('./data/raw/Dataset Wachttijden medisch-specialistische zorg 1 november 2022.csv')
     dataset_preprocessed = select_features(dataset_preprocessed)
     dataset_preprocessed = fill_missing_values(dataset_preprocessed)
     dataset_preprocessed = drop_invalid_records(dataset_preprocessed)

--- a/src/prepare_data.py
+++ b/src/prepare_data.py
@@ -1,43 +1,56 @@
 import ray
+import dask.dataframe as dd
+from ray.util.dask import enable_dask_on_ray
 from ray.data.preprocessors import OneHotEncoder
-from pyarrow.csv import ParseOptions, ConvertOptions
 
 
-def prepare_data(include_columns: list):
-    # read data
-    data_path = './data/raw/Dataset Wachttijden medisch-specialistische zorg 1 november 2022.csv'
-    dataset = ray.data.read_csv(data_path, convert_options=ConvertOptions(
-        include_columns=include_columns), parse_options=ParseOptions(delimiter=';'))
-
-    # drop missing values
-    dataset = dataset.filter(lambda row: row['WACHTTIJD'] is not None)
-
-    return dataset
+def load_data(filename):
+    df = dd.read_csv(filename, encoding='iso-8859-1', sep=';', dtype={'WACHTTIJD': 'float64'})
+    return df
 
 
-def main():
-    # read data
-    features = [
+def select_features(df: dd.DataFrame) -> dd.DataFrame:
+    feature_names = [
         'TYPE_WACHTTIJD',
         'SPECIALISME',
         'ROAZ_REGIO',
-        'TYPE_ZORGINSTELLING'
+        'TYPE_ZORGINSTELLING',
+        'WACHTTIJD'
     ]
-    target = 'WACHTTIJD'
-    dataset = prepare_data(features + [target])
 
-    # preprocess data
-    preprocessor = OneHotEncoder(features)
-    dataset_preprocessed = preprocessor.fit_transform(dataset)
+    return df[feature_names]
 
-    # split data into train and validation.
-    train_dataset, test_dataset = dataset_preprocessed.train_test_split(
-        test_size=0.2)
+
+
+def fill_missing_values(df: dd.DataFrame) -> dd.DataFrame:
+    df['TYPE_ZORGINSTELLING'] = df['TYPE_ZORGINSTELLING'].fillna('Kliniek')
+    return df
+
+
+def drop_invalid_records(df: dd.DataFrame) -> dd.DataFrame:
+    return df.dropna(subset=['WACHTTIJD'])
+
+
+def main():
+    ray.init()
+
+    enable_dask_on_ray()
+
+    dataset_preprocessed = load_data('data/wachttijden.csv')
+    dataset_preprocessed = select_features(dataset_preprocessed)
+    dataset_preprocessed = fill_missing_values(dataset_preprocessed)
+    dataset_preprocessed = drop_invalid_records(dataset_preprocessed)
+
+    final_dataset = ray.data.from_dask(dataset_preprocessed)
+
+    # split data into train and test sets.
+    train_dataset, test_dataset = final_dataset.train_test_split(test_size=0.2)
 
     # write preprocessed data to csv
     train_dataset.write_csv('./data/preprocessed/train/')
     test_dataset.write_csv('./data/preprocessed/test/')
 
+    ray.shutdown()
 
 if __name__ == '__main__':
     main()

--- a/src/train_sklearn.py
+++ b/src/train_sklearn.py
@@ -2,7 +2,7 @@ import ray
 from ray.data.dataset import Dataset
 from ray.air.result import Result
 from ray.train.sklearn import SklearnTrainer
-
+from ray.data.preprocessors import OneHotEncoder
 from sklearn.tree import DecisionTreeRegressor
 
 
@@ -14,12 +14,20 @@ def load_data():
 
 
 def train_sklearn(target: str, train_dataset: Dataset, test_dataset: Dataset) -> Result:
+    preprocessor = OneHotEncoder(columns=[
+        'TYPE_WACHTTIJD',
+        'SPECIALISME',
+        'ROAZ_REGIO',
+        'TYPE_ZORGINSTELLING',
+    ])
+
     trainer = SklearnTrainer(
+        preprocessor=preprocessor,
         estimator=DecisionTreeRegressor(),
         label_column=target,
         datasets={"train": train_dataset, "valid": test_dataset},
         cv=5,
-        scoring='neg_mean_squared_error'
+        scoring='r2'
     )
     result = trainer.fit()
     return result
@@ -30,7 +38,7 @@ def main():
     train_dataset, test_dataset = load_data()
     result = train_sklearn(target, train_dataset, test_dataset)
 
-    print(f"L2 validation score: {result.metrics['valid']['test_score']}")
+    print(f"R2 score: {result.metrics['valid']['test_score']}")
 
 
 if __name__ == '__main__':

--- a/src/tune_lightgbm.py
+++ b/src/tune_lightgbm.py
@@ -7,36 +7,19 @@ from ray.train.lightgbm import LightGBMTrainer
 from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner
 from ray.air.config import ScalingConfig
-import tempfile
-import pandas as pd
-import re
-import os
-
-
-def alter_columnnames(dir):
-    df = pd.read_csv(os.path.join(dir, os.listdir(dir)[0]))
-    df = df.rename(columns=lambda x: re.sub('[^A-Za-z0-9_]+', '', x))
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmppath = os.path.join(tmpdir, 'data.csv')
-        df.to_csv(tmppath, index=False)
-        dataset = ray.data.read_csv(tmppath)
-
-    return dataset
+from utils import get_wachttijden_categorizer
 
 
 def load_data():
-    # Because the columnnames of the data contain characters that LightGBM cannot handle,
-    # columnsnames are altered for now using pandas. I have not found a way to do this
-    # easily with Ray.
-    train_dataset = alter_columnnames('./data/preprocessed/train/')
-    test_dataset = alter_columnnames('./data/preprocessed/test/')
+    train_dataset = ray.data.read_csv('./data/preprocessed/train/')
+    test_dataset = ray.data.read_csv('./data/preprocessed/test/')
 
     return train_dataset, test_dataset
 
 
 def tune_lightgbm(target: str, train_dataset: Dataset, test_dataset: Dataset) -> Result:
     trainer = LightGBMTrainer(
+        preprocessor=get_wachttijden_categorizer(),
         scaling_config=ScalingConfig(
             # Whether to use GPU acceleration.
             use_gpu=False,

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,38 @@
+from ray.data.preprocessors import Categorizer
+import pandas as pd
+
+
+def get_wachttijden_categorizer():
+    return Categorizer(
+        columns=[
+            'TYPE_WACHTTIJD',
+            'SPECIALISME',
+            'ROAZ_REGIO',
+            'TYPE_ZORGINSTELLING',
+        ],
+        dtypes={
+            'TYPE_WACHTTIJD': pd.CategoricalDtype(['Polikliniekbezoek', 'Diagnostiek', 'Behandeling']),
+            'SPECIALISME': pd.CategoricalDtype(['Dermatologie (310)', 'Neurologie (330)',
+                                                'Maag, darm en leverziekten (318)', 'Orthopedie (305)',
+                                                'Anesthesiologie (389)', 'Radiologie (362)', 'Reumatologie (324)',
+                                                'Chirurgie (heelkunde) (303)', 'Oogheelkunde (301)',
+                                                'Orthopedie (305) / Chirurgie (heelkunde) (303)',
+                                                'Neurochirurgie (308)', 'KNO (302)', 'Plastische Chirurgie (304)',
+                                                'Interne geneeskunde (313)',
+                                                'Orthopedie (305) / Neurochirurgie (308)',
+                                                'Urologie (306) / Chirurgie (heelkunde) (303)',
+                                                'Revalidatie (327)', 'Geriatrie (335)', 'Gynaecologie (307)',
+                                                'Urologie (306)',
+                                                'Chirurgie (heelkunde) (303) / Plastische Chirurgie (304) / Orthopedie (305)',
+                                                'Cardiologie (320)', 'Revalidatiegeneeskunde (327)',
+                                                'Kindergeneeskunde (316)', 'Sportgeneeskunde', 'Kaakchirurgie',
+                                                'Longgeneeskunde (322)',
+                                                'Dermatologie (310) / Chirurgie (heelkunde) (303)',
+                                                'Psychiatrie (329)',
+                                                'KNO (302) / Longgeneeskunde (322) / Neurologie (330)', 'Overige',
+                                                'Cardiopulmonale chirurgie (328)']),
+            'ROAZ_REGIO': pd.CategoricalDtype(['Oost', 'Zuidwest-NL', 'Limburg', 'Zwolle', 'Midden-NL',
+                                               'SpzNet AMC', 'West', 'Noordwest', 'Noord-NL', 'Euregio',
+                                               'Brabant']),
+            'TYPE_ZORGINSTELLING': pd.CategoricalDtype(['Ziekenhuis', 'Kliniek']),
+        })


### PR DESCRIPTION
I had some fun trying out Dask with Ray. It's super fast on my machine now. It was fast before so I'm not sure what changed.
The API is at least a lot nicer with Dask when it comes to selecting features, filling missing values, and doing other things.

Here's what changed

* Added [poetry](https://python-poetry.org/) as a package manager to make dev setup even easier
* Added [dask](https://docs.dask.org/) for selecting features, filling missing values, and dropping missing outputs
* Moved One-hot encoding to the training pipeline. You'll need this here because it's used when doing inference too

Feel free to merge or delete. I had some free time :-)